### PR TITLE
setting 'raw to string' and an associated type conversion for sessions

### DIFF
--- a/rexpro/rexpro.go
+++ b/rexpro/rexpro.go
@@ -214,7 +214,8 @@ func (s *session) createOrKillSession(kill bool) (err error) {
 	if err != nil {
 		return err
 	}
-	s.sId = (resp[0].([]byte))
+
+	s.sId = []byte(resp[0].(string))
 
 	if h.MessageType != SESSION_RESPONSE {
 		err = fmt.Errorf("rexpro: Got msg type %d, expecting %d", h.MessageType, SESSION_RESPONSE)
@@ -362,6 +363,7 @@ func int2byte(val int) []byte {
 
 func decodeBody(body []byte) (retVal []interface{}, err error) {
 	var mh = new(codec.MsgpackHandle)
+	mh.RawToString = true
 	mh.MapType = reflect.TypeOf(map[string]interface{}(nil))
 	dec := codec.NewDecoderBytes(body, mh)
 	if e := dec.Decode(&retVal); e != nil {

--- a/rexpro/rexpro.go
+++ b/rexpro/rexpro.go
@@ -136,7 +136,7 @@ func DialTimeout(address string, graphName string, connectTimeout, readTimeout, 
 	if err != nil {
 		return nil, err
 	}
-	return NewConn(c, address, readTimeout, writeTimeout), nil
+	return NewConn(c, graphName, readTimeout, writeTimeout), nil
 }
 
 // NewConn returns a new rexpro connection for the given net connection.
@@ -216,9 +216,8 @@ func (s *session) createOrKillSession(kill bool) (err error) {
 	}
 
 	s.sId = []byte(resp[0].(string))
-
 	if h.MessageType != SESSION_RESPONSE {
-		err = fmt.Errorf("rexpro: Got msg type %d, expecting %d", h.MessageType, SESSION_RESPONSE)
+		err = fmt.Errorf("rexpro: Got msg type %d, expecting %d, body: %v", h.MessageType, SESSION_RESPONSE, resp)
 	}
 	return
 }


### PR DESCRIPTION
I prefer to have the rexpro results come back to the client as strings, as such, the session ID type conversion is different as well.
